### PR TITLE
Point at our own version of phantomjs2 binary

### DIFF
--- a/attributes/phantomjs.rb
+++ b/attributes/phantomjs.rb
@@ -1,8 +1,3 @@
-default[:phantomjs][:x86_64][:tar_url]  = "http://phantomjs.googlecode.com/files/phantomjs-1.8.0-linux-x86_64.tar.bz2"
-default[:phantomjs][:x86_64][:checksum] = "29804bfc357f961b4b17f9072b95f93c6be284ca"
-default[:phantomjs][:x86_64][:filename] = "phantomjs-1.8.0-linux-x86_64.tar.bz2"
-
-default[:phantomjs][:x86][:tar_url]     = "https://phantomjs.googlecode.com/files/phantomjs-1.7.0-linux-i686.tar.bz2"
-default[:phantomjs][:x86][:checksum]    = "4508abf55fef386a9079ed029b6d36d8719d2686"
-default[:phantomjs][:x86][:filename]    = "phantomjs-1.7.0-linux-i686.tar.bz2"
-
+default[:phantomjs][:x86_64][:tar_url]  = "https://s3.amazonaws.com/teamcity-buildagent/phantomjs-2.0.0-ubuntu-12.04.tar.bz2"
+default[:phantomjs][:x86_64][:checksum] = "4ea7aa79e45fbc487a63ef4788a18ef7"
+default[:phantomjs][:x86_64][:filename] = "phantomjs-2.0.0-ubuntu-12.04.tar.bz2"

--- a/attributes/phantomjs.rb
+++ b/attributes/phantomjs.rb
@@ -1,3 +1,7 @@
 default[:phantomjs][:x86_64][:tar_url]  = "https://s3.amazonaws.com/teamcity-buildagent/phantomjs-2.0.0-ubuntu-12.04.tar.bz2"
 default[:phantomjs][:x86_64][:checksum] = "4ea7aa79e45fbc487a63ef4788a18ef7"
 default[:phantomjs][:x86_64][:filename] = "phantomjs-2.0.0-ubuntu-12.04.tar.bz2"
+
+default[:phantomjs][:x86][:tar_url]     = "https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-1.9.8-linux-i686.tar.bz2"
+default[:phantomjs][:x86][:checksum]    = "814a438ca515c6f7b1b2259d0d5bc804"
+default[:phantomjs][:x86][:filename]    = "phantomjs-1.9.8-linux-i686.tar.bz2"

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -6,9 +6,15 @@
 #
 # All rights reserved - Do Not Redistribute
 
-tar_url = node[:phantomjs][:x86_64][:tar_url]
-tar_checksum = node[:phantomjs][:x86_64][:checksum]
-filename = node[:phantomjs][:x86_64][:filename]
+if node.kernel.machine == "x86_64"
+  tar_url = node[:phantomjs][:x86_64][:tar_url]
+  tar_checksum = node[:phantomjs][:x86_64][:checksum]
+  filename = node[:phantomjs][:x86_64][:filename]
+else
+  tar_url = node[:phantomjs][:x86][:tar_url]
+  tar_checksum = node[:phantomjs][:x86][:checksum]
+  filename = node[:phantomjs][:x86][:filename]
+end
 
 file_path = "#{Chef::Config[:file_cache_path]}/#{filename}"
 remote_file "Downloading phantomjs tar" do

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -6,15 +6,9 @@
 #
 # All rights reserved - Do Not Redistribute
 
-if node.kernel.machine == "x86_64"
-  tar_url = node[:phantomjs][:x86_64][:tar_url]
-  tar_checksum = node[:phantomjs][:x86_64][:checksum]
-  filename = node[:phantomjs][:x86_64][:filename]
-else
-  tar_url = node[:phantomjs][:x86][:tar_url]
-  tar_checksum = node[:phantomjs][:x86][:checksum]
-  filename = node[:phantomjs][:x86][:filename]
-end
+tar_url = node[:phantomjs][:x86_64][:tar_url]
+tar_checksum = node[:phantomjs][:x86_64][:checksum]
+filename = node[:phantomjs][:x86_64][:filename]
 
 file_path = "#{Chef::Config[:file_cache_path]}/#{filename}"
 remote_file "Downloading phantomjs tar" do


### PR DESCRIPTION
PhantomJS 2 is not distributing official binary packages for linux right
now. We got this binary from TravisCI - see
https://github.com/travis-ci/travis-ci/issues/3225 - rather than pulling
a binary from their S3 we felt more secure hosting it ourselves. We also
modified the structure of the archive to more closely resemble an
official distribution so that we didn't need to make bigger changes to
the cookbook.

We also removed the x86 section as it pointed at an outdated version on
a defunct google code repository.