### PR TITLE
use correct checksum for phantomjs tar file

### DIFF
--- a/attributes/phantomjs.rb
+++ b/attributes/phantomjs.rb
@@ -1,5 +1,5 @@
 default[:phantomjs][:x86_64][:tar_url]  = "https://s3.amazonaws.com/teamcity-buildagent/phantomjs-2.0.0-ubuntu-12.04.tar.bz2"
-default[:phantomjs][:x86_64][:checksum] = "4ea7aa79e45fbc487a63ef4788a18ef7"
+default[:phantomjs][:x86_64][:checksum] = "1b8479fe5166838494339d8a7af1003d"
 default[:phantomjs][:x86_64][:filename] = "phantomjs-2.0.0-ubuntu-12.04.tar.bz2"
 
 default[:phantomjs][:x86][:tar_url]     = "https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-1.9.8-linux-i686.tar.bz2"


### PR DESCRIPTION
Looks like we forgot to update the checksum after we changed the structure of the tar file to more closely match what it looks like in an official release.